### PR TITLE
Add publisher field to Book entity and update related classes

### DIFF
--- a/src/main/java/com/polarbookshop/catalogservice/domain/book/Book.java
+++ b/src/main/java/com/polarbookshop/catalogservice/domain/book/Book.java
@@ -18,9 +18,10 @@ public record Book(
         String author,
         @NotNull(message = "the book price must be defined.")
         @Positive(message = "the book price must be greater than zero.")
-        Double price
+        Double price,
+        String publisher
 ) {
     public Book withIsbn(String isbn) {
-        return new Book(isbn, this.title, this.author, this.price);
+        return new Book(isbn, this.title, this.author, this.price, this.publisher);
     }
 }

--- a/src/main/java/com/polarbookshop/catalogservice/persistence/book/BookDataLoader.java
+++ b/src/main/java/com/polarbookshop/catalogservice/persistence/book/BookDataLoader.java
@@ -28,10 +28,10 @@ public class BookDataLoader {
         }
         springDataJdbcBookRepository.deleteAll();
         List<Book> books = List.of(
-                new Book("9781617294945", "Spring in Action, Sixth Edition", "Craig Walls", 44.99),
-                new Book("9781617297574", "Spring Boot in Action", "Craig Walls", 39.99),
-                new Book("9780134686097", "Effective Java, Third Edition", "Joshua Bloch", 49.99),
-                new Book("9780596009205", "Head First Java, Second Edition", "Kathy Sierra, Bert Bates", 37.35)
+                new Book("9781617294945", "Spring in Action, Sixth Edition", "Craig Walls", 44.99, "spring"),
+                new Book("9781617297574", "Spring Boot in Action", "Craig Walls", 39.99, "spring"),
+                new Book("9780134686097", "Effective Java, Third Edition", "Joshua Bloch", 49.99, "java"),
+                new Book("9780596009205", "Head First Java, Second Edition", "Kathy Sierra, Bert Bates", 37.35, "java")
         );
         springDataJdbcBookRepository.saveAll(books.stream()
                 .map(BookEntity::of)

--- a/src/main/java/com/polarbookshop/catalogservice/persistence/book/BookEntity.java
+++ b/src/main/java/com/polarbookshop/catalogservice/persistence/book/BookEntity.java
@@ -20,6 +20,8 @@ public record BookEntity(
         String title,
         @NonNull
         String author,
+        @NonNull
+        String publisher,
         double price,
         @CreatedDate
         LocalDateTime createdDate,
@@ -39,6 +41,7 @@ public record BookEntity(
                 book.isbn(),
                 book.title(),
                 book.author(),
+                book.publisher(),
                 book.price(),
                 LocalDateTime.now(),
                 LocalDateTime.now(),
@@ -54,7 +57,8 @@ public record BookEntity(
                 this.isbn,
                 this.title,
                 this.author,
-                this.price
+                this.price,
+                this.publisher
         );
     }
 

--- a/src/main/resources/db/migration/V2__Add_publisher_column.sql
+++ b/src/main/resources/db/migration/V2__Add_publisher_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE book
+    ADD COLUMN publisher VARCHAR(255);

--- a/src/test/java/com/polarbookshop/catalogservice/CatalogServiceApplicationTests.java
+++ b/src/test/java/com/polarbookshop/catalogservice/CatalogServiceApplicationTests.java
@@ -19,7 +19,7 @@ class CatalogServiceApplicationTests {
 
     @Test
     void whenPostRequestThenBookCreated() {
-        Book expected = new Book("1234567890", "Title", "Author", 9.90);
+        Book expected = new Book("1234567890", "Title", "Author", 9.90, "publisher");
         webTestClient.post()
                 .uri("/books")
                 .bodyValue(expected)

--- a/src/test/java/com/polarbookshop/catalogservice/domain/BookValidationTest.java
+++ b/src/test/java/com/polarbookshop/catalogservice/domain/BookValidationTest.java
@@ -23,14 +23,14 @@ public class BookValidationTest {
 
     @Test
     void whenAllFieldsCorrectThenValidationSucceeds() {
-        Book book = new Book("1234567890", "Title", "Author", 9.90);
+        Book book = new Book("1234567890", "Title", "Author", 9.90, "publisher");
         Set<ConstraintViolation<Book>> violations = validator.validate(book);
         assertThat(violations).isEmpty();
     }
 
     @Test
     void whenIsbnDefinedButIncorrectThenValidationFails() {
-        Book book = new Book("123456789", "Title", "Author", 9.90);
+        Book book = new Book("123456789", "Title", "Author", 9.90, "publisher");
         Set<ConstraintViolation<Book>> violations = validator.validate(book);
         assertThat(violations).hasSize(1);
         assertThat(violations.iterator().next().getMessage()).isEqualTo("The ISBN format must be valid (either 10 or 13 digits)");

--- a/src/test/java/com/polarbookshop/catalogservice/persistance/SpringDataJdbcBookRepositoryTest.java
+++ b/src/test/java/com/polarbookshop/catalogservice/persistance/SpringDataJdbcBookRepositoryTest.java
@@ -37,10 +37,10 @@ public class SpringDataJdbcBookRepositoryTest {
 
     @Test
     void mergeTest() {
-        BookEntity entity = BookEntity.of(new Book("1234567890", "Title", "Author", 9.90));
+        BookEntity entity = BookEntity.of(new Book("1234567890", "Title", "Author", 9.90, "publisher"));
         BookEntity save = repository.merge(entity);
 
-        BookEntity merged = repository.merge(BookEntity.of(new Book(save.isbn(), "New Title", "New Author", 19.90)));
+        BookEntity merged = repository.merge(BookEntity.of(new Book(save.isbn(), "New Title", "New Author", 19.90, "publisher")));
 
         assertThat(merged.title()).isEqualTo("New Title");
         assertThat(merged.author()).isEqualTo("New Author");
@@ -53,7 +53,7 @@ public class SpringDataJdbcBookRepositoryTest {
     @Test
     void findBookByIsbnIfExistTest() {
         String isbn = "1234567890";
-        BookEntity entity = BookEntity.of(new Book(isbn, "Title", "Author", 9.90));
+        BookEntity entity = BookEntity.of(new Book(isbn, "Title", "Author", 9.90, "publisher"));
         jdbcAggregateTemplate.insert(entity);
 
         Optional<BookEntity> actual = repository.findByIsbn(isbn);

--- a/src/test/java/com/polarbookshop/catalogservice/web/BookJsonTest.java
+++ b/src/test/java/com/polarbookshop/catalogservice/web/BookJsonTest.java
@@ -18,7 +18,7 @@ class BookJsonTest {
 
     @Test
     void testSerialize() throws IOException {
-        Book book = new Book("1234567890", "Title", "Author", 9.90);
+        Book book = new Book("1234567890", "Title", "Author", 9.90, "publisher");
         JsonContent<Book> jsonContent = json.write(book);
         assertThat(jsonContent).extractingJsonPathStringValue("@.isbn")
                 .isEqualTo(book.isbn());
@@ -32,8 +32,8 @@ class BookJsonTest {
 
     @Test
     void testDeserialize() throws IOException {
-        String content = "{\"isbn\":\"1234567890\",\"title\":\"Title\",\"author\":\"Author\",\"price\":9.90}";
-        Book book = new Book("1234567890", "Title", "Author", 9.90);
+        String content = "{\"isbn\":\"1234567890\",\"title\":\"Title\",\"author\":\"Author\",\"price\":9.90,\"publisher\":\"publisher\"}";
+        Book book = new Book("1234567890", "Title", "Author", 9.90, "publisher");
         assertThat(json.parse(content)).isEqualTo(book);
     }
 }


### PR DESCRIPTION
This pull request introduces support for a new `publisher` field to the book domain model, updates persistence and validation logic accordingly, and ensures tests and database schema are consistent with the change. The main goal is to allow each book to store its publisher information throughout the application.

**Domain model and persistence updates:**

* Added a new `publisher` field to the `Book` and `BookEntity` records, updated constructors and conversion methods to handle the new field. [[1]](diffhunk://#diff-0ce5bf0a20247d53db3d75e6400fa1575f7ad5e4816a086224ea57202721e2abL21-R25) [[2]](diffhunk://#diff-a5eb76a6554add4f8b0ad78ab2025ae1620e794f956859594e4d44510852e3f8R23-R24) [[3]](diffhunk://#diff-a5eb76a6554add4f8b0ad78ab2025ae1620e794f956859594e4d44510852e3f8R44) [[4]](diffhunk://#diff-a5eb76a6554add4f8b0ad78ab2025ae1620e794f956859594e4d44510852e3f8L57-R61)

* Updated the database schema to add a `publisher` column to the `book` table via a migration script.

**Data and test updates:**

* Modified the book data loader to include publisher information for each book entry.

* Updated all relevant tests to use the new constructor and include the `publisher` field in test data and JSON serialization/deserialization checks. [[1]](diffhunk://#diff-9bf64f7f84541c50a38af9630f76bc6013af5be6eedd9e39fdaba825353655a0L22-R22) [[2]](diffhunk://#diff-d1ce1f52e70fa556f3ff3fdb3f86b35649354887442f90f5be26a95092313321L26-R33) [[3]](diffhunk://#diff-9c2c459abbe5dba17d36c42b6d874887d3b9a6837af01a0d6ed202c1442bc8b3L40-R43) [[4]](diffhunk://#diff-9c2c459abbe5dba17d36c42b6d874887d3b9a6837af01a0d6ed202c1442bc8b3L56-R56) [[5]](diffhunk://#diff-f9d7581fa0c813201d375d26a7278c04a02c619484c0384a4e9b2f2f72ba17a7L21-R21) [[6]](diffhunk://#diff-f9d7581fa0c813201d375d26a7278c04a02c619484c0384a4e9b2f2f72ba17a7L35-R36)