### PR TITLE
Containerizing spring boot

### DIFF
--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -1,15 +1,19 @@
 name: "Commit Stage"
 on: "push"
+env:
+  REGISTRY: "ghcr.io"
+  IMAGE_NAME: "shayfoo/catalog-service"
+  VERSION: "latest"
 jobs:
   build:
     name: "Build and Test"
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-24.04"
     permissions:
       contents: read
       security-events: write
     steps:
       - name: "Checkout source code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: "Set up JDK 25"
         uses: actions/setup-java@v5
         with:
@@ -32,3 +36,47 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build
+  package:
+    name: "Package and Publish"
+    if: "${{ github.ref == 'refs/heads/main'}}"
+    needs: [ "build" ]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+    steps:
+      - name: "Checkout source code"
+        uses: /actions/checkout@v5
+      - name: "Set up JDK 25"
+        uses: actions/setup-java@v5
+        with:
+          java-version: "25"
+          distribution: "corretto"
+          cache: "gradle"
+      - name: "Build container image"
+        run: |
+          chmod +x gradlew
+          ./gradlew jlinkDockerBuildImage \
+            --imageName ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+      - name: "Image vulnerability scanning"
+        uses: "anchore/scan-action@v6"
+        id: scan
+        with:
+          image-reference: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}"
+          fail-build: "true"
+          severity-cutoff: high
+          acs-report-enable: true
+      - name: "Upload vulnerability report"
+        uses: "github/codeql-action/upload-sarif@v3"
+        with:
+          sarif_file: "${{ steps.scan.outputs.sarif }}"
+      - name: "Log into container registry"
+        uses: docker/login-actions@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Publish container image"
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM amazoncorretto:25-al2023 AS builder
+WORKDIR /workspace
+
+COPY . .
+
+RUN yum install -y findutils
+
+RUN ./gradlew bootJar
+ARG JAR_FILE=build/libs/*.jar
+# https://docs.spring.io/spring-boot/reference/packaging/container-images/dockerfiles.html
+COPY ${JAR_FILE} application.jar
+RUN java -Djarmode=tools -jar application.jar extract --layers --destination extracted
+
+FROM amazoncorretto:25-al2023 AS runtime
+
+RUN yum install -y shadow-utils
+
+# タイムゾーンをAsia/Tokyoに設定
+RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+RUN echo "Asia/Tokyo" > /etc/timezone
+ENV LANG=ja_JP.UTF-8
+ENV LANGUAGE=ja_JP:ja
+ENV LC_ALL=ja_JP.UTF-8
+
+# appuserの作成
+RUN groupadd -g 1000 appuser && useradd -m -u 1000 -g 1000 appuser
+
+# 作成したappuserに切り替え
+USER appuser
+WORKDIR /home/appuser
+
+# Copy the layers from the builder stage
+COPY --chown=1000:1000 --from=builder /workspace/extracted/dependencies/ ./
+COPY --chown=1000:1000 --from=builder /workspace/extracted/spring-boot-loader/ ./
+COPY --chown=1000:1000 --from=builder /workspace/extracted/snapshot-dependencies/ ./
+COPY --chown=1000:1000 --from=builder /workspace/extracted/application/ ./
+
+ENTRYPOINT ["java",  "-jar", "application.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
@@ -62,4 +63,23 @@ dependencyManagement {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+// cloud native buildpack settings
+tasks.named<BootBuildImage>("bootBuildImage") {
+    environment = mapOf(
+        "BP_JVM_VERSION" to "25",
+        "BP_JVM_TIMEZONE" to "Asia/Tokyo",
+        "LANG" to "ja_JP.UTF-8",
+        "LANGUAGE" to "ja_JP:ja",
+        "LC_ALL" to "ja_JP.UTF-8"
+    )
+    imageName = project.name
+    docker {
+        publishRegistry {
+            username = project.findProperty("registryUsername")?.toString()
+            password = project.findProperty("registryToken")?.toString()
+            url = project.findProject("registryUrl")?.toString()
+        }
+    }
 }

--- a/local/db/docker-compose.yaml
+++ b/local/db/docker-compose.yaml
@@ -9,4 +9,7 @@ services:
     ports:
       - "5432:5432"
     restart: unless-stopped
-
+    networks:
+      - catalog-network
+networks:
+  catalog-network:


### PR DESCRIPTION
This pull request introduces several improvements to the CI/CD pipeline and Docker setup for the project, focusing on automating container image building, vulnerability scanning, and publishing. It also updates the Dockerfile for better image layering and runtime configuration, and enhances local development networking for the database.

### CI/CD workflow enhancements

* Added a new `package` job to `.github/workflows/commit-stage.yaml` that builds, scans for vulnerabilities, and publishes the container image to GitHub Container Registry, triggered only on pushes to the `main` branch.
* Updated runner version to `ubuntu-24.04` and bumped `actions/checkout` to v5 in the workflow for improved compatibility and performance.

### Dockerfile improvements

* Introduced a multi-stage `Dockerfile` using Amazon Corretto 25, with builder and runtime stages, timezone and locale configuration for Japan, and a non-root `appuser` for security. The image is now layered for efficient caching and distribution.

### Local development configuration

* Added a custom `catalog-network` to the local database `docker-compose.yaml` to improve service isolation and communication.