### PR TITLE
chap-7-Kubernetes

### DIFF
--- a/.github/workflows/commit-stage.yaml
+++ b/.github/workflows/commit-stage.yaml
@@ -35,6 +35,11 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew build
+      - name: Validate Kubernetes manifest
+        uses: "stackrox/kube-linter-action@v1.0.7"
+        with:
+          directory: k8s
+          fail-on-invalid-resource: true
   package:
     name: "Package and Publish"
     if: "${{ github.ref == 'refs/heads/main'}}"

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,18 @@
+# Build
+custom_build(
+    # Name of the container image
+    ref = 'catalog-service',
+    # command to build the image
+    command='./gradlew bootBuildImage --imageName $EXPECTED_REF',
+    # files to watch for changes
+    deps=['build.gradle.kts', 'src']
+)
+
+# Deploy
+k8s_yaml(['k8s/deployment.yaml', 'k8s/service.yaml'])
+
+# Manage
+k8s_resource(
+    'catalog-service',
+    port_forwards=['9001']
+)

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,8 +2,8 @@
 custom_build(
     # Name of the container image
     ref = 'catalog-service',
-    # command to build the image
-    command='./gradlew bootBuildImage --imageName $EXPECTED_REF',
+    # Command to build the image - using env parameter for cross-platform compatibility
+    command='gradlew bootBuildImage --imageName %EXPECTED_REF%',
     # files to watch for changes
     deps=['build.gradle.kts', 'src']
 )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
 }
 
 dependencyManagement {
@@ -72,7 +74,7 @@ tasks.named<BootBuildImage>("bootBuildImage") {
         "BP_JVM_TIMEZONE" to "Asia/Tokyo",
         "LANG" to "ja_JP.UTF-8",
         "LANGUAGE" to "ja_JP:ja",
-        "LC_ALL" to "ja_JP.UTF-8"
+        "LC_ALL" to "ja_JP.UTF-8",
     )
     imageName = project.name
     docker {

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalog-service
+  labels:
+    app: catalog-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalog-service
+  template:
+    metadata:
+      labels:
+        app: catalog-service
+    spec:
+      containers:
+        - name: catalog-service
+          image: catalog-service
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sh", "-c", "sleep 5" ]
+          ports:
+            - containerPort: 9001
+          env:
+            - name: BPL_JVM_THREAD_COUNT
+              value: "50"
+            - name: SPRING_DATASOURCE_URL
+              value: jdbc:postgresql://polar-postgres/polardb_catalog
+            - name: SPRING_PROFILES_ACTIVE
+              value: testdata

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: catalog-service
+  labels:
+    app: catalog-service
+spec:
+  type: ClusterIP
+  selector:
+    app: catalog-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 9001

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,8 @@ spring:
         initial-interval: 1000
         max-interval: 2000
         multiplier: 1.1
+  lifecycle:
+    timeout-per-shutdown-phase: 15s
   datasource:
     username: user
     password: password
@@ -30,6 +32,7 @@ management:
         include: refresh
 server:
   port: 9001
+  shutdown: graceful
   tomcat:
     connection-timeout: 2s
     keep-alive-timeout: 15s


### PR DESCRIPTION
This pull request introduces Kubernetes support and local development tooling for the `catalog-service`, along with improvements to application lifecycle management and CI/CD validation. The main changes are grouped below.

**Kubernetes Integration and Local Development:**

* Added `k8s/deployment.yaml` and `k8s/service.yaml` to define Kubernetes deployment and service resources for the `catalog-service`, including container configuration, environment variables, and port mappings. [[1]](diffhunk://#diff-4bbade0e44f036b32fc63c2e5838f57268ec49ff70dfce1afb9e12849515dd38R1-R33) [[2]](diffhunk://#diff-427c18a0ed4a36634147b26d71347f2755fb5db12571eb0ceb80949186700fc5R1-R14)
* Introduced a `Tiltfile` to enable local development workflows with Tilt, including custom image build, deployment of Kubernetes manifests, and port forwarding for the service.

**CI/CD and Manifest Validation:**

* Updated `.github/workflows/commit-stage.yaml` to include a Kubernetes manifest validation step using `stackrox/kube-linter-action`, ensuring best practices and resource validity during CI.

**Application Lifecycle and Graceful Shutdown:**

* Enhanced application lifecycle management in `application.yaml` by configuring `spring.lifecycle.timeout-per-shutdown-phase` and enabling graceful shutdown for the embedded server. [[1]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061R17-R18) [[2]](diffhunk://#diff-b4c0421bcb3280a8e738550c830dba197057c515bcdd9579a52cbfe9adca2061R35)